### PR TITLE
Corrected Windows Batch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ bash:
 
 batch (windows cmd.exe):
 
-`FOR /f "tokens=*" %i IN ('"gvm.exe" gvm 1.9') DO %i`
+`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.9') DO %i`
 
 powershell:
 


### PR DESCRIPTION
The current windows batch command in README.md is wrong and results in the following error:

```
C:\FOR /f "tokens=*" %i IN ('"gvm.exe" gvm 1.9') DO %i
gvm: error: unexpected 1.9
```

Removed the extra gvm in the commit.