### PR TITLE
Change default macOS install directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ go version
 macOS:
 
 ``` bash
-# macOS Example (assumes ~/bin is in PATH).
-curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.0.5/gvm-darwin-amd64
-chmod +x ~/bin/gvm
+# macOS Example
+curl -sL -o /usr/local/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.0.5/gvm-darwin-amd64
+chmod +x /usr/local/bin/gvm
 eval "$(gvm 1.9.2)"
 go version
 ```


### PR DESCRIPTION
The README suggests installing `gvm` under `~/bin`, but this folder is not a folder that exists normally under macOS.

In macOS it's instead normal to install user supplied binaries under `/usr/local/bin`. This folder should be in the `PATH` by default, so defaulting to this instead of `~/bin` would make it easier to use the tool under macOS I IMHO.