### PR TITLE
Add command to set the Powershell TLS version before downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ go version
 Windows (Powershell):
 
 ```
+[Net.ServicePointManager]::SecurityProtocol = "tls12"
 Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v0.0.5/gvm-windows-amd64.exe -Outfile C:\Windows\System32\gvm.exe
 gvm --format=powershell 1.10 | Invoke-Expression
 go version


### PR DESCRIPTION
By default poweshell at least on windows 2012 default to TLS1.0, github
requires TLS1.2 so we have to change the value before downloading the
executable.
