### PR TITLE
Add support to install go from source

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,0 +1,102 @@
+package gvm
+
+import (
+	"bufio"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type command struct {
+	Path   string
+	Args   []string
+	Dir    string
+	Stdout func(string)
+	Stderr func(string)
+}
+
+func makeCommand(cmd string, args ...string) *command {
+	return &command{
+		Path: cmd,
+		Args: args,
+	}
+}
+
+func (c *command) WithLogger(log logrus.FieldLogger) *command {
+	if c.Stdout == nil {
+		c.Stdout = infoOutLog(log)
+	}
+	if c.Stderr == nil {
+		c.Stderr = errOutLog(log)
+	}
+	return c
+}
+
+func (c *command) WithDir(dir string) *command {
+	c.Dir = dir
+	return c
+}
+
+func infoOutLog(log logrus.FieldLogger) func(string) {
+	return makeOutLog(log.Info)
+}
+
+func errOutLog(log logrus.FieldLogger) func(string) {
+	return makeOutLog(log.Error)
+}
+
+func makeOutLog(fn func(...interface{})) func(string) {
+	return func(text string) { fn(text) }
+}
+
+func (c *command) Exec() error {
+	cmd := exec.Command(c.Path, c.Args...)
+	cmd.Dir = c.Dir
+
+	var err error
+	var stdout, stderr io.ReadCloser
+	if c.Stdout != nil {
+		stdout, err = cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		defer stdout.Close()
+	}
+
+	if c.Stderr != nil {
+		stderr, err = cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		defer stderr.Close()
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	captureLines := func(in io.Reader, fn func(string)) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(in)
+		for scanner.Scan() {
+			text := scanner.Text()
+			fn(text)
+		}
+	}
+
+	if stdout != nil {
+		wg.Add(1)
+		go captureLines(stdout, c.Stdout)
+	}
+	if stderr != nil {
+		wg.Add(1)
+		go captureLines(stderr, c.Stderr)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}

--- a/cmd.go
+++ b/cmd.go
@@ -3,6 +3,7 @@ package gvm
 import (
 	"bufio"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 
@@ -13,6 +14,7 @@ type command struct {
 	Path   string
 	Args   []string
 	Dir    string
+	Env    []string
 	Stdout func(string)
 	Stderr func(string)
 }
@@ -54,6 +56,10 @@ func makeOutLog(fn func(...interface{})) func(string) {
 func (c *command) Exec() error {
 	cmd := exec.Command(c.Path, c.Args...)
 	cmd.Dir = c.Dir
+
+	if len(c.Env) > 0 {
+		cmd.Env = append(os.Environ(), c.Env...)
+	}
 
 	var err error
 	var stdout, stderr io.ReadCloser

--- a/cmd/gvm/avail.go
+++ b/cmd/gvm/avail.go
@@ -9,13 +9,17 @@ import (
 
 func availCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
 	return func(manager *gvm.Manager) error {
-		list, err := manager.Available()
+		list, hasBin, err := manager.Available()
 		if err != nil {
 			return err
 		}
 
-		for _, v := range list {
-			fmt.Println(v)
+		for i, v := range list {
+			if hasBin[i] {
+				fmt.Printf("%v\t(source, binary)\n", v)
+			} else {
+				fmt.Printf("%v\t(source)\n", v)
+			}
 		}
 		return nil
 	}

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -48,6 +48,12 @@ func main() {
 		return cmd
 	}
 
+	app.Flag("os", "Go binaries target os.").StringVar(&manager.GOOS)
+	app.Flag("arch", "Go binaries target architecture.").StringVar(&manager.GOOS)
+	app.Flag("home", "GVM home directory.").StringVar(&manager.Home)
+	app.Flag("url", "Go binaries repository base URL.").StringVar(&manager.GoStorageHome)
+	app.Flag("repository", "Go upstream git repository.").StringVar(&manager.GoSourceURL)
+
 	command(useCommand, "use", "prepare go version and print environment variables").
 		Default()
 	command(initCommand, "init", "init .gvm and update source cache")

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -50,6 +50,7 @@ func main() {
 
 	command(useCommand, "use", "prepare go version and print environment variables").
 		Default()
+	command(initCommand, "init", "init .gvm and update source cache")
 	command(installCommand, "install", "install go version if not already installed")
 	command(availCommand, "available", "list all installable go versions")
 	command(listCommand, "list", "list installed versions")

--- a/cmd/gvm/init.go
+++ b/cmd/gvm/init.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/andrewkroh/gvm"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+func initCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
+	return func(manager *gvm.Manager) error {
+		return manager.UpdateCache()
+	}
+}

--- a/cmd/gvm/install.go
+++ b/cmd/gvm/install.go
@@ -9,6 +9,8 @@ import (
 
 func installCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
 	var version string
+	var build bool
+	cmd.Flag("build", "Build go version from source").Short('b').BoolVar(&build)
 	cmd.Arg("version", "Go version to install (e.g. 1.10).").StringVar(&version)
 
 	return func(manager *gvm.Manager) error {
@@ -29,8 +31,14 @@ func installCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
 			return nil
 		}
 
-		fmt.Printf("Installing go-%v. Please wait...\n", version)
-		dir, err := manager.Install(ver)
+		var dir string
+		if build {
+			fmt.Printf("Building go-%v. Please wait...\n", version)
+			dir, err = manager.Build(ver)
+		} else {
+			fmt.Printf("Installing go-%v. Please wait...\n", version)
+			dir, err = manager.Install(ver)
+		}
 		if err != nil {
 			fmt.Println("Installation failed with:\n", err)
 			return err

--- a/cmd/gvm/use.go
+++ b/cmd/gvm/use.go
@@ -11,6 +11,7 @@ import (
 
 type useCmd struct {
 	version string
+	build   bool
 	format  string
 }
 
@@ -18,6 +19,7 @@ func useCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
 	ctx := &useCmd{}
 
 	cmd.Arg("version", "Go version to install (e.g. 1.10).").StringVar(&ctx.version)
+	cmd.Flag("build", "Build go version from source").Short('b').BoolVar(&ctx.build)
 	cmd.Flag("format", "Format to use for the shell commands. Options: bash, batch, powershell").
 		Short('f').
 		Default(shellfmt.DefaultFormat()).
@@ -41,7 +43,12 @@ func (cmd *useCmd) Run(manager *gvm.Manager) error {
 		return err
 	}
 
-	goroot, err := manager.Install(ver)
+	var goroot string
+	if cmd.build {
+		goroot, err = manager.Build(ver)
+	} else {
+		goroot, err = manager.Install(ver)
+	}
 	if err != nil {
 		return err
 	}

--- a/gvm.go
+++ b/gvm.go
@@ -25,6 +25,9 @@ type Manager struct {
 	// Defaults to https://storage.googleapis.com/golang
 	GoStorageHome string
 
+	// GoSourceURL configres the update git repository to download and update local
+	// source checkouts from.
+	// Defaults to https://go.googlesource.com/go
 	GoSourceURL string
 
 	Logger logrus.FieldLogger

--- a/gvm.go
+++ b/gvm.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
 )
 
 type Manager struct {
@@ -23,8 +25,13 @@ type Manager struct {
 	// Defaults to https://storage.googleapis.com/golang
 	GoStorageHome string
 
+	GoSourceURL string
+
+	Logger logrus.FieldLogger
+
 	cacheDir    string
 	versionsDir string
+	logsDir     string
 }
 
 func (m *Manager) Init() error {
@@ -41,6 +48,10 @@ func (m *Manager) Init() error {
 		m.GoStorageHome = "https://storage.googleapis.com/golang"
 	}
 
+	if m.GoSourceURL == "" {
+		m.GoSourceURL = "https://go.googlesource.com/go"
+	}
+
 	if m.GOOS == "" {
 		m.GOOS = runtime.GOOS
 	}
@@ -54,13 +65,22 @@ func (m *Manager) Init() error {
 		}
 	}
 
+	if m.Logger == nil {
+		m.Logger = logrus.StandardLogger()
+	}
+
 	m.cacheDir = filepath.Join(m.Home, "cache")
 	m.versionsDir = filepath.Join(m.Home, "versions")
+	m.logsDir = filepath.Join(m.Home, "logs")
 	return m.ensureDirStruct()
 }
 
+func (m *Manager) UpdateCache() error {
+	return m.updateSrcCache()
+}
+
 func (m *Manager) ensureDirStruct() error {
-	for _, dir := range []string{m.cacheDir, m.versionsDir} {
+	for _, dir := range []string{m.cacheDir, m.versionsDir, m.logsDir} {
 		if err := os.MkdirAll(dir, os.ModeDir|0755); err != nil {
 			return err
 		}
@@ -68,8 +88,36 @@ func (m *Manager) ensureDirStruct() error {
 	return nil
 }
 
-func (m *Manager) Available() ([]*GoVersion, error) {
-	return m.AvailableBinaries()
+func (m *Manager) Available() ([]*GoVersion, []bool, error) {
+	if !m.hasSrcCache() {
+		versions, err := m.AvailableBinaries()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		hasBin := make([]bool, len(versions))
+		for i := range hasBin {
+			hasBin[i] = true
+		}
+		return versions, hasBin, nil
+	}
+
+	src, err := m.AvailableSource()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hasBin := make([]bool, len(src))
+	bin, err := m.AvailableBinaries()
+	if err != nil {
+		return src, hasBin, nil
+	}
+
+	for i, ver := range src {
+		hasBin[i] = findVersion(ver, bin) >= 0
+	}
+
+	return src, hasBin, nil
 }
 
 func (m *Manager) Remove(version *GoVersion) error {
@@ -128,7 +176,11 @@ func (m *Manager) versionDir(version *GoVersion) string {
 	return fmt.Sprintf("go%v.%v.%v", version, m.GOOS, m.GOARCH)
 }
 
-func (m *Manager) Install(version *GoVersion) (string, error) {
+func (m *Manager) Build(version *GoVersion) (string, error) {
+	if version.IsTip() {
+		return m.ensureUpToDateTip()
+	}
+
 	has, err := m.HasVersion(version)
 	if err != nil {
 		return "", err
@@ -137,5 +189,53 @@ func (m *Manager) Install(version *GoVersion) (string, error) {
 		return m.VersionGoROOT(version), nil
 	}
 
-	return m.installBinary(version)
+	return m.installSrc(version)
+}
+
+func (m *Manager) Install(version *GoVersion) (string, error) {
+	if version.IsTip() {
+		return m.ensureUpToDateTip()
+	}
+
+	has, err := m.HasVersion(version)
+	if err != nil {
+		return "", err
+	}
+	if has {
+		return m.VersionGoROOT(version), nil
+	}
+
+	tryBinary := !version.IsTip()
+	if tryBinary {
+		dir, err := m.installBinary(version)
+		if err == nil {
+			return dir, err
+		}
+	}
+
+	return m.installSrc(version)
+}
+
+func (m *Manager) ensureUpToDateTip() (string, error) {
+	version, _ := ParseVersion("tip")
+
+	has, err := m.HasVersion(version)
+	if err != nil {
+		return "", err
+	}
+
+	// no updates since last build -> return installed version
+	if has {
+		updates, err := m.tryRefreshSrcCache()
+		if err != nil {
+			return "", err
+		}
+
+		if !updates {
+			return m.VersionGoROOT(version), nil
+		}
+	}
+
+	// new updates in cache -> rebuild
+	return m.installSrc(version)
 }

--- a/srcrepo.go
+++ b/srcrepo.go
@@ -1,0 +1,321 @@
+package gvm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type srcCacheInfo struct {
+	Updated time.Time
+}
+
+func (m *Manager) srcCacheDir() string {
+	return filepath.Join(m.cacheDir, "go")
+}
+
+func (m *Manager) hasSrcCache() bool {
+	localGoSrc := m.srcCacheDir()
+	exists, err := existsDir(localGoSrc)
+	return err == nil && exists
+}
+
+func (m *Manager) ensureSrcCache() error {
+	localGoSrc := m.srcCacheDir()
+	exists, err := existsDir(localGoSrc)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	return m.updateSrcCache()
+}
+
+func (m *Manager) updateSrcCache() error {
+	localGoSrc := filepath.Join(m.cacheDir, "go")
+	exists, err := existsDir(localGoSrc)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		err = gitClone(m.Logger, localGoSrc, m.GoSourceURL, true)
+	} else {
+		err = gitFetch(m.Logger, localGoSrc)
+	}
+	if err != nil {
+		return err
+	}
+
+	return writeJsonFile(filepath.Join(m.cacheDir, "go.meta"), srcCacheInfo{
+		Updated: time.Now(),
+	})
+}
+
+func (m *Manager) installSrc(version *GoVersion) (string, error) {
+	log := m.Logger
+
+	if err := m.ensureSrcCache(); err != nil {
+		return "", err
+	}
+
+	tag := "master"
+	to := m.VersionGoROOT(version)
+
+	exists, err := existsDir(to)
+	if err != nil {
+		return "", err
+	}
+
+	if !version.IsTip() {
+		tag = fmt.Sprintf("go%v", version)
+		if err := m.ensureSrcVersionAvail(version); err != nil {
+			return "", err
+		}
+	}
+
+	godir := m.versionDir(version)
+
+	log.Println("create temp directory")
+	tmpRoot, err := ioutil.TempDir("", godir)
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	err = buildGo(log, tmpRoot, m.srcCacheDir(), version.String(), tag)
+	if err != nil {
+		return "", err
+	}
+
+	if exists {
+		log.Println("remove old installation")
+		if err := os.RemoveAll(to); err != nil {
+			return "", err
+		}
+	}
+
+	// move final build result into destination
+	log.Println("rename")
+	if err = os.Rename(filepath.Join(tmpRoot, "go"), to); err != nil {
+		return "", err
+	}
+	return to, nil
+}
+
+func buildGo(log logrus.FieldLogger, buildDir, repo, version, tag string) error {
+	log.Println("copy cache")
+	tmp := filepath.Join(buildDir, "go")
+	if err := gitClone(log, tmp, repo, false); err != nil {
+		return err
+	}
+	log.Println("checkout tag:", tag)
+	if err := gitCheckout(log, tmp, tag); err != nil {
+		return err
+	}
+
+	if version != "tip" {
+		// write VERSION file
+		versionFile := filepath.Join(tmp, "go", "VERSION")
+		err := ioutil.WriteFile(versionFile, []byte(version), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.RemoveAll(filepath.Join(tmp, "go", ".git")); err != nil {
+		return err
+	}
+
+	log.Println("build")
+	srcDir := filepath.Join(tmp, "src")
+
+	var cmd *command
+	if runtime.GOOS == "windows" {
+		cmd = makeCommand("cmd", "/C", "make.bat")
+	} else {
+		cmd = makeCommand("bash", "make.bash")
+	}
+	return cmd.WithDir(srcDir).WithLogger(log).Exec()
+}
+
+func (m *Manager) hasSrcVersion(version *GoVersion) (bool, error) {
+	log := m.Logger
+	localGoSrc := filepath.Join(m.cacheDir, "go")
+
+	tag := fmt.Sprintf("go%s", version)
+	log.Println("check version tag")
+	hasTag := false
+	err := gitListTags(log, localGoSrc, func(t string) { hasTag = hasTag || t == tag })
+	return hasTag, err
+}
+
+func (m *Manager) ensureSrcVersionAvail(version *GoVersion) error {
+	has, err := m.hasSrcVersion(version)
+	if err != nil {
+		return err
+	}
+
+	if !has {
+		if err := m.updateSrcCache(); err != nil {
+			return err
+		}
+		has, err = m.hasSrcVersion(version)
+		if err != nil {
+			return err
+		}
+	}
+	if !has {
+		return fmt.Errorf("unknown version %s", version)
+	}
+	return nil
+}
+
+func (m *Manager) tryRefreshSrcCache() (bool, error) {
+	log := m.Logger
+
+	localGoSrc := m.srcCacheDir()
+	exists, err := existsDir(localGoSrc)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Println("Go cache not found")
+		err := m.updateSrcCache()
+		return err == nil, err
+	}
+
+	info := srcCacheInfo{}
+	if err := readJsonFile(filepath.Join(m.cacheDir, "go.meta"), &info); err != nil {
+		return false, err
+	}
+
+	updTS := info.Updated
+	now := time.Now()
+	if now.Before(updTS) {
+		return false, nil
+	}
+
+	// don't refresh cache if still same day
+	if updTS.Day() == now.Day() && updTS.Month() == now.Month() && updTS.Year() == updTS.Year() {
+		return false, nil
+	}
+
+	log.Println("Fetch updates")
+	if err := m.updateSrcCache(); err != nil {
+		return false, err // update cache failed
+	}
+
+	// check for updates ;)
+	cTS, err := gitLastCommitTs(log, m.srcCacheDir())
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("last update ts=%v, last commit ts=%v\n", updTS, cTS)
+
+	// check new commits have been added since last refresh
+	updates := updTS.Before(cTS)
+	if updates {
+		log.Println("New commits since last build")
+	} else {
+		log.Println("No New commits since last build")
+	}
+
+	return updates, nil
+}
+
+func (m *Manager) AvailableSource() ([]*GoVersion, error) {
+	localGoSrc := m.srcCacheDir()
+	var versions []*GoVersion
+	err := gitListTags(m.Logger, localGoSrc, func(tag string) {
+		if !strings.HasPrefix(tag, "go") {
+			return
+		}
+
+		ver, err := ParseVersion(tag[2:])
+		if err != nil {
+			return
+		}
+
+		versions = append(versions, ver)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	tip, _ := ParseVersion("tip")
+	versions = append(versions, tip)
+	sortVersions(versions)
+	return versions, err
+}
+
+func gitClone(logger logrus.FieldLogger, to string, url string, bare bool) error {
+	tmpDir := to + ".tmp"
+	if err := os.Mkdir(tmpDir, 0755); err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	args := []string{"clone"}
+	if bare {
+		args = append(args, "--bare")
+	}
+	args = append(args, url, tmpDir)
+
+	logger.Println("git clone:")
+	cmd := makeCommand("git", args...).WithLogger(logger)
+	if err := cmd.Exec(); err != nil {
+		return err
+	}
+
+	// Move into the final location.
+	return os.Rename(tmpDir, to)
+}
+
+func gitLastCommitTs(logger logrus.FieldLogger, path string) (time.Time, error) {
+	var tsLine string
+
+	logger.Println("git log:")
+	cmd := makeCommand("git", "log", "-n", "1", "--pretty=format:%ct")
+	cmd.Stdout = func(l string) { tsLine = l }
+	err := cmd.WithDir(path).WithLogger(logger).Exec()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	i, err := strconv.ParseInt(tsLine, 10, 64)
+	return time.Unix(i, 0), nil
+}
+
+func gitFetch(logger logrus.FieldLogger, path string) error {
+	logger.Println("git fetch:")
+	return makeCommand("git", "fetch").WithDir(path).WithLogger(logger).Exec()
+}
+
+func gitPull(logger logrus.FieldLogger, path string) error {
+	logger.Println("git pull:")
+	return makeCommand("git", "pull").WithDir(path).WithLogger(logger).Exec()
+}
+
+func gitCheckout(logger logrus.FieldLogger, path, tag string) error {
+	logger.Println("git checkout:")
+	return makeCommand("git", "checkout", tag).WithDir(path).WithLogger(logger).Exec()
+}
+
+func gitListTags(logger logrus.FieldLogger, path string, fn func(string)) error {
+	logger.Println("git tag:")
+	cmd := makeCommand("git", "tag").WithDir(path).WithLogger(logger)
+	cmd.Stdout = fn
+	return cmd.Exec()
+}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,8 @@
 package gvm
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,4 +54,20 @@ func existsDir(dir string) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+func writeJsonFile(filename string, value interface{}) error {
+	contents, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, contents, 0644)
+}
+
+func readJsonFile(filename string, to interface{}) error {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(contents, to)
 }

--- a/version.go
+++ b/version.go
@@ -84,3 +84,19 @@ func sortVersions(versions []*GoVersion) {
 		return versions[i].LessThan(versions[j])
 	})
 }
+
+func (v *GoVersion) IsTip() bool {
+	return v.in == "tip"
+}
+
+func findVersion(version *GoVersion, versions []*GoVersion) int {
+	i := sort.Search(len(versions), func(i int) bool {
+		ver := versions[i]
+		return version.in == ver.in || version.LessThan(ver)
+	})
+
+	if i < len(versions) && versions[i].in == version.in {
+		return i
+	}
+	return -1
+}


### PR DESCRIPTION
- Building go is optional. If binaries are installed only, no source code is ever checked out or downloaded
- Source code is checked out as bare repository into ~/.gvm/cache/go
- To force building from source pass `-b` flag to `use` or `install` command (version is only build if not already installed)
- Installer tries to get binary version first. Only if this fails we fall back to building from source (local source checkout can act as cache)
- Version `tip` is always build from source
- When using `tip`, the cache is only updated once per day. `tip` is rebuild if new commits are found in the repository
- Introduce `gvm init` command. `init` clones the git repository or forces a `git fetch`.
- Expose some more flags like target os, arch, gvm home directory, ...

Building from source requires an active go environment (use gvm to install a binary) and git for checkout. On Windows `cmd /C make.bat` is used for building. Other systems will run `bash make.bash`.