### PR TITLE
retry file downloads 3 times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## Added
+
+- Add logic to retry failed downloads. #15
+
 ## [0.1.0]
 
 ### Added

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/andrewkroh/gvm"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 const usage = `gvm is a Go version manager. gvm installs a Go version and prints

--- a/common/common.go
+++ b/common/common.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
@@ -14,28 +16,45 @@ var log = logrus.WithField("package", "common")
 
 func DownloadFile(url, destinationDir string) (string, error) {
 	log.WithField("url", url).Debug("downloading file")
+	var name string
+	var err error
+	var retry bool
+	for a := 1; a <= 3; a++ {
+		name, err, retry = downloadFile(url, destinationDir)
+		if err != nil && retry {
+			log.WithError(err).Debug(fmt.Sprintf("Attempt %d failed", a))
+			continue
+		}
+		break
+	}
+	return name, err
+}
 
-	resp, err := http.Get(url)
+func downloadFile(url, destinationDir string) (string, error, bool) {
+	client := http.Client{
+		Timeout: time.Duration(3 * time.Minute),
+	}
+	resp, err := client.Get(url)
 	if err != nil {
-		return "", errors.Wrap(err, "http get failed")
+		return "", errors.Wrap(err, "http get failed"), true
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("download failed with http status %v", resp.StatusCode)
+		return "", errors.Errorf("download failed with http status %v", resp.StatusCode), resp.StatusCode != http.StatusNotFound
 	}
 
 	name := filepath.Join(destinationDir, filepath.Base(url))
 	f, err := os.Create(name)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create output file")
+		return "", errors.Wrap(err, "failed to create output file"), false
 	}
 
 	numBytes, err := io.Copy(f, resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to write file to disk")
+		return "", errors.Wrap(err, "failed to write file to disk"), true
 	}
 	log.WithFields(logrus.Fields{"file": name, "size_bytes": numBytes}).Debug("download complete")
 
-	return name, nil
+	return name, nil, false
 }

--- a/common/common.go
+++ b/common/common.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"os"

--- a/common/common.go
+++ b/common/common.go
@@ -22,7 +22,7 @@ func DownloadFile(url, destinationDir string) (string, error) {
 	for a := 1; a <= 3; a++ {
 		name, err, retry = downloadFile(url, destinationDir)
 		if err != nil && retry {
-			log.WithError(err).Debug(fmt.Sprintf("Attempt %d failed", a))
+			log.WithError(err).Debugf("Attempt %d failed", a)
 			continue
 		}
 		break


### PR DESCRIPTION
and set timeout on http get.

In an attempt to combat CI issues like:

```
gvm: error: http get failed: Get https://storage.googleapis.com/golang/go1.11.4.linux-amd64.tar.gz: dial tcp 173.194.197.128:443: i/o timeout
```