### PR TITLE
doc: Typo in the batch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ bash:
 batch (windows cmd.exe):
 
 
-`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.12.7') DO %i`
+`FOR /f "tokens=*" %%i IN ('"gvm.exe" 1.12.7') DO %i`
 
 powershell:
 


### PR DESCRIPTION
there is a `%` missed