### PR TITLE
Add cmd.exe example details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ bash:
 
 `eval "$(gvm 1.12.7)"`
 
-batch (windows cmd.exe):
-
+cmd.exe (for batch scripts %i should be substituted with %%i):
 
 `FOR /f "tokens=*" %i IN ('"gvm.exe" 1.12.7') DO %i`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bash:
 
 `eval "$(gvm 1.12.7)"`
 
-cmd.exe (for batch scripts %i should be substituted with %%i):
+cmd.exe (for batch scripts `%i` should be substituted with `%%i`):
 
 `FOR /f "tokens=*" %i IN ('"gvm.exe" 1.12.7') DO %i`
 


### PR DESCRIPTION
%i is for use on command lines only.
For batch scripts %i should be substituted with %%i.