### PR TITLE
Fix output of --format match for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.2]
+
+### Fixed
+
+- Fix output of `--format match` to remove a stray `$` character. #25
+
 ## [0.2.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ shells.
 
 bash:
 
-`eval "$(gvm 1.12.7)"`
+`eval "$(gvm 1.13.8)"`
 
 cmd.exe (for batch scripts `%i` should be substituted with `%%i`):
 
-`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.12.7') DO %i`
+`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.13.8') DO %i`
 
 powershell:
 
-`gvm --format=powershell 1.12.7 | Invoke-Expression`
+`gvm --format=powershell 1.13.8 | Invoke-Expression`
 
 Installation
 ------------
@@ -33,7 +33,7 @@ Linux:
 # Linux Example (assumes ~/bin is in PATH).
 curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.2.0/gvm-linux-amd64
 chmod +x ~/bin/gvm
-eval "$(gvm 1.12.7)"
+eval "$(gvm 1.13.8)"
 go version
 ```
 
@@ -43,7 +43,7 @@ macOS:
 # macOS Example
 curl -sL -o /usr/local/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.2.0/gvm-darwin-amd64
 chmod +x /usr/local/bin/gvm
-eval "$(gvm 1.12.7)"
+eval "$(gvm 1.13.8)"
 go version
 ```
 
@@ -52,13 +52,13 @@ Windows (Powershell):
 ```
 [Net.ServicePointManager]::SecurityProtocol = "tls12"
 Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v0.2.0/gvm-windows-amd64.exe -Outfile C:\Windows\System32\gvm.exe
-gvm --format=powershell 1.12.7 | Invoke-Expression
+gvm --format=powershell 1.13.8 | Invoke-Expression
 go version
 ```
 
 Fish Shell:
 
-Use `gvm` with fish shell by executing `gvm 1.12.7 | source` in lieu of using `eval`.
+Use `gvm` with fish shell by executing `gvm 1.13.8 | source` in lieu of using `eval`.
 
 For existing Go users:
 

--- a/cmd/gvm/internal/shellfmt/format.go
+++ b/cmd/gvm/internal/shellfmt/format.go
@@ -100,10 +100,10 @@ func (f *batchFormatter) Set(name, val string) string {
 }
 
 func (f *batchFormatter) Prepend(name, val string) string {
-	return fmt.Sprintf(`set %v=%v;$%v`, name, val, os.Getenv(name))
+	return fmt.Sprintf(`set %v=%v;%v`, name, val, os.Getenv(name))
 }
 func (f *batchFormatter) Append(name, val string) string {
-	return fmt.Sprintf(`set %v=$%v;%v`, name, os.Getenv(name), val)
+	return fmt.Sprintf(`set %v=%v;%v`, name, os.Getenv(name), val)
 }
 
 func (f *powershellFormatter) Set(name, val string) string {


### PR DESCRIPTION
Fix output of `--format match` to remove a stray `$` character