### PR TITLE
Log warning when binary package install fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed 
 
 - Use Go 1.15 to build project. [#28](https://github.com/andrewkroh/gvm/pull/28)
+- Log a warning when binary package install fails. [#29](https://github.com/andrewkroh/gvm/pull/29)
 
 ## [0.2.2]
 

--- a/binrepo.go
+++ b/binrepo.go
@@ -34,7 +34,7 @@ func (m *Manager) installBinary(version *GoVersion) (string, error) {
 	goURL := fmt.Sprintf("%s/go%v.%v-%v.%v", m.GoStorageHome, version, m.GOOS, m.GOARCH, extension)
 	path, err := common.DownloadFile(goURL, tmp)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed downloading from %v: %w", goURL, err)
 	}
 
 	return extractTo(m.VersionGoROOT(version), path)

--- a/gvm.go
+++ b/gvm.go
@@ -212,8 +212,11 @@ func (m *Manager) Install(version *GoVersion) (string, error) {
 	if tryBinary {
 		dir, err := m.installBinary(version)
 		if err == nil {
-			return dir, err
+			return dir, nil
 		}
+		m.Logger.WithFields(logrus.Fields{"version": version, "error": err}).
+			Warn("Failed to install Go from binary package. Trying to " +
+				"install from source.")
 	}
 
 	return m.installSrc(version)


### PR DESCRIPTION
The code silently falls back to installing from source when a binary
package fails to install. So log a warning when this happens.