### PR TITLE
Replace os.Rename with common.Rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix errors with renames failing across disks by falling back to a copy/delete. [#30](https://github.com/andrewkroh/gvm/pull/30)
+
 ## [0.2.3]
 
 ### Changed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix errors with renames failing across disks by falling back to a copy/delete. [#30](https://github.com/andrewkroh/gvm/pull/30)
+- Fix errors with renames failing across disks by falling back to a copy/delete. [#31](https://github.com/andrewkroh/gvm/pull/31)
 
 ## [0.2.3]
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/hashicorp/go-version v1.2.0
+	github.com/otiai10/copy v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,12 @@ github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+d
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
+github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/srcrepo.go
+++ b/srcrepo.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/andrewkroh/gvm/common"
 )
 
 type srcCacheInfo struct {
@@ -107,7 +109,7 @@ func (m *Manager) installSrc(version *GoVersion) (string, error) {
 
 	// move final build result into destination
 	log.Println("rename")
-	if err = os.Rename(filepath.Join(tmpRoot, "go"), to); err != nil {
+	if err = common.Rename(filepath.Join(tmpRoot, "go"), to); err != nil {
 		return "", err
 	}
 	return to, nil
@@ -292,7 +294,7 @@ func gitClone(logger logrus.FieldLogger, to string, url string, bare bool) error
 	}
 
 	// Move into the final location.
-	return os.Rename(tmpDir, to)
+	return common.Rename(tmpDir, to)
 }
 
 func gitLastCommitTs(logger logrus.FieldLogger, path string) (time.Time, error) {

--- a/util.go
+++ b/util.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/andrewkroh/gvm/common"
 	"github.com/pkg/errors"
+
+	"github.com/andrewkroh/gvm/common"
 )
 
 func homeDir() (string, error) {
@@ -38,7 +39,7 @@ func extractTo(to, file string) (string, error) {
 	}
 
 	// Move into the final location.
-	if err := os.Rename(filepath.Join(tmpDir, "go"), to); err != nil {
+	if err := common.Rename(filepath.Join(tmpDir, "go"), to); err != nil {
 		return "", err
 	}
 	return to, nil


### PR DESCRIPTION
common.Rename tries to use os.Rename but falls-back to copy/delete on
failure. This allows operation across disks to succeed.

Also add better error handling in the extract functions.