### PR TITLE
Fall back to source install only when binary URL is 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix errors with renames failing across disks by falling back to a copy/delete. [#31](https://github.com/andrewkroh/gvm/pull/31)
-
+- Fall back to a source code based install only when binary package URL returns
+  with HTTP 404. [#30](https://github.com/andrewkroh/gvm/issues/30) [#32](https://github.com/andrewkroh/gvm/pull/32)
+  
 ## [0.2.3]
 
 ### Changed 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/gvm.go
+++ b/gvm.go
@@ -1,6 +1,7 @@
 package gvm
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/andrewkroh/gvm/common"
 )
 
 type Manager struct {
@@ -214,9 +217,10 @@ func (m *Manager) Install(version *GoVersion) (string, error) {
 		if err == nil {
 			return dir, nil
 		}
-		m.Logger.WithFields(logrus.Fields{"version": version, "error": err}).
-			Warn("Failed to install Go from binary package. Trying to " +
-				"install from source.")
+		// Only continue to installing from source if the server confirms 404.
+		if !errors.Is(err, common.ErrNotFound) {
+			return "", err
+		}
 	}
 
 	return m.installSrc(version)


### PR DESCRIPTION
When the install from a binary package fails it falls back to installing from source. Tthe only case where the fallback
should occur is when the server responds with a 404 that no binary package exists. Otherwise it's falling back on
various IO or permissions errors.

Fixes #30