### PR TITLE
Improve 'gvm available'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use Go 1.17 to build project. [#40](https://github.com/andrewkroh/gvm/pull/40)
 
+### Fixed
+
+- Fix staleness issues with the `gvm available` output. [#39](https://github.com/andrewkroh/gvm/issues/39) [#41](https://github.com/andrewkroh/gvm/pull/41)
+
 ## [0.3.0]
 
 ### Added

--- a/cmd/gvm/avail.go
+++ b/cmd/gvm/avail.go
@@ -9,17 +9,13 @@ import (
 
 func availCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {
 	return func(manager *gvm.Manager) error {
-		list, hasBin, err := manager.Available()
+		list, err := manager.Available()
 		if err != nil {
 			return err
 		}
 
-		for i, v := range list {
-			if hasBin[i] {
-				fmt.Printf("%v\t(source, binary)\n", v)
-			} else {
-				fmt.Printf("%v\t(source)\n", v)
-			}
+		for _, v := range list {
+			fmt.Println(v)
 		}
 		return nil
 	}

--- a/version.go
+++ b/version.go
@@ -88,15 +88,3 @@ func sortVersions(versions []*GoVersion) {
 func (v *GoVersion) IsTip() bool {
 	return v.in == "tip"
 }
-
-func findVersion(version *GoVersion, versions []*GoVersion) int {
-	i := sort.Search(len(versions), func(i int) bool {
-		ver := versions[i]
-		return version.in == ver.in || version.LessThan(ver)
-	})
-
-	if i < len(versions) && versions[i].in == version.in {
-		return i
-	}
-	return -1
-}


### PR DESCRIPTION
This improves the `gvm available` command to ensure the data returned is as accurate as possible.
It addresses a few different issues.

The command uses the a cached copy of the Go git repo to list the available version tags. This will
now refresh the source repo if the cache is not from the current day.

The tags from the source repo were the only ones that were listed in the output. Each of those versions
were then annotated with whether a binary version is available. So if the source repo was stale you
would never newly released binary versions. This changes the output to merge the list of source repo
tags and binary releases so that you generally always see the latest data.

Fixes #39

### Outputs

### No source repo present
[available-no-source.txt](https://github.com/andrewkroh/gvm/files/7475010/available-no-source.txt)
```
1.4.3	(binary)
1.5beta2	(binary)
1.5beta3	(binary)
1.5rc1	(binary)
1.5	(binary)
1.5.1	(binary)
1.5.2	(binary)
1.5.3	(binary)
1.5.4	(binary)
1.6beta1	(binary)
1.6beta2	(binary)
1.6rc1	(binary)
1.6rc2	(binary)
1.6	(binary)
1.6.1	(binary)
1.6.2	(binary)
1.6.3	(binary)
1.6.4	(binary)
1.7beta1	(binary)
1.7beta2	(binary)
1.7rc1	(binary)
1.7rc2	(binary)
1.7rc3	(binary)
1.7rc4	(binary)
1.7rc5	(binary)
1.7rc6	(binary)
1.7	(binary)
1.7.1	(binary)
1.7.2	(binary)
1.7.3	(binary)
1.7.4	(binary)
1.7.5	(binary)
1.7.6	(binary)
1.8beta1	(binary)
1.8beta2	(binary)
1.8rc1	(binary)
1.8rc2	(binary)
1.8rc3	(binary)
1.8	(binary)
1.8.1	(binary)
1.8.2	(binary)
1.8.3	(binary)
1.8.4	(binary)
1.8rc4	(binary)
1.8.5	(binary)
1.8.6	(binary)
1.8.7	(binary)
1.9beta1	(binary)
1.9beta2	(binary)
1.9rc1	(binary)
1.9rc2	(binary)
1.9	(binary)
1.9.1	(binary)
1.9rc2	(binary)
1.9.2	(binary)
1.9.3	(binary)
1.9.4	(binary)
1.9.5	(binary)
1.9.6	(binary)
1.9.7	(binary)
1.10beta1	(binary)
1.10beta2	(binary)
1.10rc1	(binary)
1.10rc2	(binary)
1.10	(binary)
1.10.1	(binary)
1.10.2	(binary)
1.10.3	(binary)
1.10.4	(binary)
1.10.5	(binary)
1.10.6	(binary)
1.10.7	(binary)
1.10.8	(binary)
1.11beta1	(binary)
1.11beta2	(binary)
1.11beta3	(binary)
1.11rc1	(binary)
1.11rc2	(binary)
1.11	(binary)
1.11.1	(binary)
1.11.2	(binary)
1.11.3	(binary)
1.11.4	(binary)
1.11.5	(binary)
1.11.6	(binary)
1.11.7	(binary)
1.11.8	(binary)
1.11.9	(binary)
1.11.10	(binary)
1.11.11	(binary)
1.11.12	(binary)
1.11.13	(binary)
1.12beta1	(binary)
1.12beta2	(binary)
1.12rc1	(binary)
1.12	(binary)
1.12.1	(binary)
1.12.2	(binary)
1.12.3	(binary)
1.12.4	(binary)
1.12.5	(binary)
1.12.6	(binary)
1.12.7	(binary)
1.12.8	(binary)
1.12.9	(binary)
1.12.10	(binary)
1.12.11	(binary)
1.12.12	(binary)
1.12.13	(binary)
1.12.14	(binary)
1.12.15	(binary)
1.12.16	(binary)
1.12.17	(binary)
1.13beta1	(binary)
1.13rc1	(binary)
1.13rc2	(binary)
1.13	(binary)
1.13.1	(binary)
1.13.2	(binary)
1.13.3	(binary)
1.13.4	(binary)
1.13.5	(binary)
1.13.6	(binary)
1.13.7	(binary)
1.13.8	(binary)
1.13.9	(binary)
1.13.10	(binary)
1.13.11	(binary)
1.13.12	(binary)
1.13.13	(binary)
1.13.14	(binary)
1.13.15	(binary)
1.14beta1	(binary)
1.14rc1	(binary)
1.14	(binary)
1.14.1	(binary)
1.14.2	(binary)
1.14.3	(binary)
1.14.4	(binary)
1.14.5	(binary)
1.14.6	(binary)
1.14.7	(binary)
1.14.8	(binary)
1.14.9	(binary)
1.14.10	(binary)
1.14.11	(binary)
1.14.12	(binary)
1.14.13	(binary)
1.14.14	(binary)
1.14.15	(binary)
1.15beta1	(binary)
1.15rc1	(binary)
1.15rc2	(binary)
1.15	(binary)
1.15.1	(binary)
1.15.2	(binary)
1.15.3	(binary)
1.15.4	(binary)
1.15.5	(binary)
1.15.6	(binary)
1.15.7	(binary)
1.15.8	(binary)
1.15.9	(binary)
1.15.10	(binary)
1.15.11	(binary)
1.15.12	(binary)
1.15.13	(binary)
1.15.14	(binary)
1.15.15	(binary)
1.16beta1	(binary)
1.16rc1	(binary)
1.16	(binary)
1.16.1	(binary)
1.16.2	(binary)
1.16.3	(binary)
1.16.4	(binary)
1.16.5	(binary)
1.16.6	(binary)
1.16.7	(binary)
1.16.8	(binary)
1.16.9	(binary)
1.17beta1	(binary)
1.17rc1	(binary)
1.17rc2	(binary)
1.17	(binary)
1.17.1	(binary)
1.17.2	(binary)
```

### With cached source repo
[available-with-source.txt](https://github.com/andrewkroh/gvm/files/7475011/available-with-source.txt)
```
1.0	(source)
1.0.1	(source)
1.0.2	(source)
1.0.3	(source)
1.1rc2	(source)
1.1rc3	(source)
1.1	(source)
1.1.1	(source)
1.1.2	(source)
1.2rc2	(source)
1.2rc3	(source)
1.2rc4	(source)
1.2rc5	(source)
1.2	(source)
1.2.1	(source)
1.2.2	(source)
1.3beta1	(source)
1.3beta2	(source)
1.3rc1	(source)
1.3rc2	(source)
1.3	(source)
1.3.1	(source)
1.3.2	(source)
1.3.3	(source)
1.4beta1	(source)
1.4rc1	(source)
1.4rc2	(source)
1.4	(source)
1.4.1	(source)
1.4.2	(source)
1.4.3	(source, binary)
1.5beta1	(source)
1.5beta2	(source, binary)
1.5beta3	(source, binary)
1.5rc1	(source, binary)
1.5	(source, binary)
1.5.1	(source, binary)
1.5.2	(source, binary)
1.5.3	(source, binary)
1.5.4	(source, binary)
1.6beta1	(source, binary)
1.6beta2	(source, binary)
1.6rc1	(source, binary)
1.6rc2	(source, binary)
1.6	(source, binary)
1.6.1	(source, binary)
1.6.2	(source, binary)
1.6.3	(source, binary)
1.6.4	(source, binary)
1.7beta1	(source, binary)
1.7beta2	(source, binary)
1.7rc1	(source, binary)
1.7rc2	(source, binary)
1.7rc3	(source, binary)
1.7rc4	(source, binary)
1.7rc5	(source, binary)
1.7rc6	(source, binary)
1.7	(source, binary)
1.7.1	(source, binary)
1.7.2	(source, binary)
1.7.3	(source, binary)
1.7.4	(source, binary)
1.7.5	(source, binary)
1.7.6	(source, binary)
1.8beta1	(source, binary)
1.8beta2	(source, binary)
1.8rc1	(source, binary)
1.8rc2	(source, binary)
1.8rc3	(source, binary)
1.8	(source, binary)
1.8.1	(source, binary)
1.8.2	(source, binary)
1.8.3	(source, binary)
1.8.4	(source, binary)
1.8rc4	(source, binary)
1.8rc5	(source)
1.8.5	(source, binary)
1.8.6	(source, binary)
1.8.7	(source, binary)
1.9beta1	(source, binary)
1.9beta2	(source, binary)
1.9rc1	(source, binary)
1.9rc2	(source, binary)
1.9	(source, binary)
1.9.1	(source, binary)
1.9.2	(source, binary)
1.9.3	(source, binary)
1.9.4	(source, binary)
1.9.5	(source, binary)
1.9.6	(source, binary)
1.9.7	(source, binary)
1.10beta1	(source, binary)
1.10beta2	(source, binary)
1.10rc1	(source, binary)
1.10rc2	(source, binary)
1.10	(source, binary)
1.10.1	(source, binary)
1.10.2	(source, binary)
1.10.3	(source, binary)
1.10.4	(source, binary)
1.10.5	(source, binary)
1.10.6	(source, binary)
1.10.7	(source, binary)
1.10.8	(source, binary)
1.11beta1	(source, binary)
1.11beta2	(source, binary)
1.11beta3	(source, binary)
1.11rc1	(source, binary)
1.11rc2	(source, binary)
1.11	(source, binary)
1.11.1	(source, binary)
1.11.2	(source, binary)
1.11.3	(source, binary)
1.11.4	(source, binary)
1.11.5	(source, binary)
1.11.6	(source, binary)
1.11.7	(source, binary)
1.11.8	(source, binary)
1.11.9	(source, binary)
1.11.10	(source, binary)
1.11.11	(source, binary)
1.11.12	(source, binary)
1.11.13	(source, binary)
1.12beta1	(source, binary)
1.12beta2	(source, binary)
1.12rc1	(source, binary)
1.12	(source, binary)
1.12.1	(source, binary)
1.12.2	(source, binary)
1.12.3	(source, binary)
1.12.4	(source, binary)
1.12.5	(source, binary)
1.12.6	(source, binary)
1.12.7	(source, binary)
1.12.8	(source, binary)
1.12.9	(source, binary)
1.12.10	(source, binary)
1.12.11	(source, binary)
1.12.12	(source, binary)
1.12.13	(source, binary)
1.12.14	(source, binary)
1.12.15	(source, binary)
1.12.16	(source, binary)
1.12.17	(source, binary)
1.13beta1	(source, binary)
1.13rc1	(source, binary)
1.13rc2	(source, binary)
1.13	(source, binary)
1.13.1	(source, binary)
1.13.2	(source, binary)
1.13.3	(source, binary)
1.13.4	(source, binary)
1.13.5	(source, binary)
1.13.6	(source, binary)
1.13.7	(source, binary)
1.13.8	(source, binary)
1.13.9	(source, binary)
1.13.10	(source, binary)
1.13.11	(source, binary)
1.13.12	(source, binary)
1.13.13	(source, binary)
1.13.14	(source, binary)
1.13.15	(source, binary)
1.14beta1	(source, binary)
1.14rc1	(source, binary)
1.14	(source, binary)
1.14.1	(source, binary)
1.14.2	(source, binary)
1.14.3	(source, binary)
1.14.4	(source, binary)
1.14.5	(source, binary)
1.14.6	(source, binary)
1.14.7	(source, binary)
1.14.8	(source, binary)
1.14.9	(source, binary)
1.14.10	(source, binary)
1.14.11	(source, binary)
1.14.12	(source, binary)
1.14.13	(source, binary)
1.14.14	(source, binary)
1.14.15	(source, binary)
1.15beta1	(source, binary)
1.15rc1	(source, binary)
1.15rc2	(source, binary)
1.15	(source, binary)
1.15.1	(source, binary)
1.15.2	(source, binary)
1.15.3	(source, binary)
1.15.4	(source, binary)
1.15.5	(source, binary)
1.15.6	(source, binary)
1.15.7	(source, binary)
1.15.8	(source, binary)
1.15.9	(source, binary)
1.15.10	(source, binary)
1.15.11	(source, binary)
1.15.12	(source, binary)
1.15.13	(source, binary)
1.15.14	(source, binary)
1.15.15	(source, binary)
1.16beta1	(source, binary)
1.16rc1	(source, binary)
1.16	(source, binary)
1.16.1	(source, binary)
1.16.2	(source, binary)
1.16.3	(source, binary)
1.16.4	(source, binary)
1.16.5	(source, binary)
1.16.6	(source, binary)
1.16.7	(source, binary)
1.16.8	(source, binary)
1.16.9	(source, binary)
1.17beta1	(source, binary)
1.17rc1	(source, binary)
1.17rc2	(source, binary)
1.17	(source, binary)
1.17.1	(source, binary)
1.17.2	(source, binary)
tip	(source)
```
