### PR TITLE
Fix GVM_ARCH env var and --arch CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix `--arch` flag and associated `GVM_ARCH` env variable. [#53](https://github.com/andrewkroh/gvm/pull/53)
+
 ### Added
 
 ## [0.4.1]

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	app.Flag("os", "Go binaries target os.").StringVar(&manager.GOOS)
-	app.Flag("arch", "Go binaries target architecture.").StringVar(&manager.GOOS)
+	app.Flag("arch", "Go binaries target architecture.").StringVar(&manager.GOARCH)
 	app.Flag("home", "GVM home directory.").StringVar(&manager.Home)
 	app.Flag("url", "Go binaries repository base URL.").StringVar(&manager.GoStorageHome)
 	app.Flag("repository", "Go upstream git repository.").StringVar(&manager.GoSourceURL)


### PR DESCRIPTION
The code is setting the GOOS value when it should have been setting GOARCH.