### PR TITLE
Test installing from source

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Lint
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Release
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   goreleaser:
+    name: GoReleaser
     runs-on: ubuntu-latest
     steps:
       -

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -90,6 +91,7 @@ func main() {
 	}
 
 	logrus.Debug("GVM version: ", version)
+	logrus.Debug("GVM arch: ", runtime.GOARCH)
 
 	action, exists := commands[selCommand]
 	if !exists {

--- a/cmd/gvm/use.go
+++ b/cmd/gvm/use.go
@@ -11,10 +11,10 @@ import (
 )
 
 type useCmd struct {
-	version string
-	build,
-	noInstall bool
-	format string
+	version   string // Go version.
+	build     bool   // Build from source only.
+	noInstall bool   // If the version is not found locally then don't install it.
+	format    string // Shell command format to output.
 }
 
 func useCommand(cmd *kingpin.CmdClause) func(*gvm.Manager) error {

--- a/cmd/gvm/use_test.go
+++ b/cmd/gvm/use_test.go
@@ -41,7 +41,7 @@ func TestGVMRunUse(t *testing.T) {
 		// Check that newer versions which use go.mod can be build from source.
 		{Version: "1.16.14", FromSource: true, Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
 		// Check that older versions which did not use go.mod can be build from source.
-		{Version: "1.7.4", FromSource: true, Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
+		{Version: "1.10.8", FromSource: true, Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
 		// Check that GO15VENDOREXPERIMENT is added for Go 1.5.
 		// NOTE: 1.5 requires Go 1.4 for bootstrapping if built from source.
 		{Version: "1.5.4", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH", `export GO15VENDOREXPERIMENT="1"`}},

--- a/cmd/gvm/use_test.go
+++ b/cmd/gvm/use_test.go
@@ -21,6 +21,7 @@ import (
 var (
 	go1_6  = gvm.MustParseVersion("1.6")
 	go1_9  = gvm.MustParseVersion("1.9")
+	go1_11 = gvm.MustParseVersion("1.11")
 	go1_16 = gvm.MustParseVersion("1.16")
 )
 
@@ -62,6 +63,10 @@ func TestGVMRunUse(t *testing.T) {
 			// by only testing on platforms where Go 1.5 is available as a binary.
 			if ver.LessThan(go1_6) && runtime.GOARCH != "amd64" {
 				t.Skip("Binary distributions of Go 1.5 are not available.")
+			}
+
+			if tc.FromSource && runtime.GOOS == "darwin" && ver.LessThan(go1_11) {
+				t.Skip("Go 1.10 fails on MacOS 12. https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue")
 			}
 
 			output, err := withStdout(func() {

--- a/cmd/gvm/use_test.go
+++ b/cmd/gvm/use_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go/build"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -16,22 +18,52 @@ import (
 	"github.com/andrewkroh/gvm"
 )
 
+var (
+	go1_6  = gvm.MustParseVersion("1.6")
+	go1_9  = gvm.MustParseVersion("1.9")
+	go1_16 = gvm.MustParseVersion("1.16")
+)
+
 func TestGVMRunUse(t *testing.T) {
+	// When testing building from source GOROOT_BOOTSTRAP must be set.
+	t.Setenv("GOROOT_BOOTSTRAP", build.Default.GOROOT)
+
 	cases := []struct {
-		Version string
-		Format  string
-		Cmds    []string
+		Version    string
+		Format     string
+		Cmds       []string
+		FromSource bool
 	}{
-		{"1.7.4", "bash", []string{"export GOROOT=", "export PATH"}},
-		{"1.7.4", "batch", []string{"set GOROOT=", "set PATH"}},
-		{"1.7.4", "powershell", []string{"$env:GOROOT = ", "$env:PATH ="}},
-		{"1.5.4", "bash", []string{"export GOROOT=", "export PATH", `export GO15VENDOREXPERIMENT="1"`}},
-		{"1.5.4", "batch", []string{"set GOROOT=", "set PATH=", `set GO15VENDOREXPERIMENT=1`}},
-		{"1.5.4", "powershell", []string{"$env:GOROOT = ", "$env:PATH =", `$env:GO15VENDOREXPERIMENT = "1"`}},
+		// Using 1.16+ allows testing on Apple M1.
+		{Version: "1.16.15", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
+		{Version: "1.16.15", Format: "batch", Cmds: []string{"set GOROOT=", "set PATH"}},
+		{Version: "1.16.15", Format: "powershell", Cmds: []string{"$env:GOROOT = ", "$env:PATH ="}},
+		// Check that newer versions which use go.mod can be build from source.
+		{Version: "1.16.14", FromSource: true, Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
+		// Check that older versions which did not use go.mod can be build from source.
+		{Version: "1.7.4", FromSource: true, Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
+		// Check that GO15VENDOREXPERIMENT is added for Go 1.5.
+		// NOTE: 1.5 requires Go 1.4 for bootstrapping if built from source.
+		{Version: "1.5.4", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH", `export GO15VENDOREXPERIMENT="1"`}},
+		{Version: "1.5.4", Format: "batch", Cmds: []string{"set GOROOT=", "set PATH=", `set GO15VENDOREXPERIMENT=1`}},
+		{Version: "1.5.4", Format: "powershell", Cmds: []string{"$env:GOROOT = ", "$env:PATH =", `$env:GO15VENDOREXPERIMENT = "1"`}},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%v_%v", tc.Version, tc.Format), func(t *testing.T) {
+			ver := gvm.MustParseVersion(tc.Version)
+
+			// Go introduced support for Apple M1 in Go 1.16.
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && ver.LessThan(go1_16) {
+				t.Skip("darwin/arm64 only supports Go 1.16 and newer")
+			}
+
+			// Go 1.5 needs Go 1.4 to build it from source so avoid that problem
+			// by only testing on platforms where Go 1.5 is available as a binary.
+			if ver.LessThan(go1_6) && runtime.GOARCH != "amd64" {
+				t.Skip("Binary distributions of Go 1.5 are not available.")
+			}
+
 			output, err := withStdout(func() {
 				manager := &gvm.Manager{}
 				if err := manager.Init(); err != nil {
@@ -41,6 +73,7 @@ func TestGVMRunUse(t *testing.T) {
 				cmd := &useCmd{
 					version: tc.Version,
 					format:  tc.Format,
+					build:   tc.FromSource,
 				}
 				err := cmd.Run(manager)
 				if err != nil {
@@ -51,10 +84,11 @@ func TestGVMRunUse(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			output = strings.TrimSpace(output)
 			t.Log(output)
 			lines := strings.Split(output, "\n")
 
-			if !assert.Len(t, lines, len(tc.Cmds)+1, "expected %d lines, got [%v]", strings.Join(lines, "|")) {
+			if !assert.Lenf(t, lines, len(tc.Cmds), "expected %d lines, got %d [%v]", len(lines), len(tc.Cmds)+1, strings.Join(lines, "|")) {
 				return
 			}
 
@@ -73,7 +107,11 @@ func TestGVMRunUse(t *testing.T) {
 
 			// Test that GOROOT/bin/go exists and is the correct version.
 			goVersionCmd := exec.Command(filepath.Join(goroot, "bin", "go"), "version")
-			goVersionCmd.Env = append(goVersionCmd.Env, "GOROOT="+goroot)
+
+			// Go versions less than 1.9 require GOROOT to be set.
+			if ver.LessThan(go1_9) {
+				goVersionCmd.Env = append(goVersionCmd.Env, "GOROOT="+goroot)
+			}
 
 			version, err := goVersionCmd.Output()
 			if err != nil {

--- a/version.go
+++ b/version.go
@@ -12,6 +12,16 @@ type GoVersion struct {
 	version *version.Version
 }
 
+// MustParseVersion parses the given Go version to return a GoVersion.
+// Otherwise, it panics.
+func MustParseVersion(in string) *GoVersion {
+	v, err := ParseVersion(in)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 func ParseVersion(in string) (*GoVersion, error) {
 	var v *version.Version
 


### PR DESCRIPTION
Add an explicit test that installs Go from source.

Skip certain tests based on the runtime GOOS and GOARCH because you cannot install some of the specified versions that are older on platforms that newly gained Go support.