### PR TITLE
adjust version naming convention for >=1.21

### DIFF
--- a/cmd/gvm/use_test.go
+++ b/cmd/gvm/use_test.go
@@ -35,6 +35,8 @@ func TestGVMRunUse(t *testing.T) {
 		Cmds       []string
 		FromSource bool
 	}{
+		{Version: "1.21.0", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
+		{Version: "1.21", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
 		// Using 1.16+ allows testing on Apple M1.
 		{Version: "1.16.15", Format: "bash", Cmds: []string{"export GOROOT=", "export PATH"}},
 		{Version: "1.16.15", Format: "batch", Cmds: []string{"set GOROOT=", "set PATH"}},

--- a/common/extract.go
+++ b/common/extract.go
@@ -128,12 +128,12 @@ func untar(r io.Reader, dir string) (err error) {
 			// write will fail with the same error.
 			dir := filepath.Dir(abs)
 			if !madeDir[dir] {
-				if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 					return err
 				}
 				madeDir[dir] = true
 			}
-			if runtime.GOOS == "darwin" && mode&0111 != 0 {
+			if runtime.GOOS == "darwin" && mode&0o111 != 0 {
 				// The darwin kernel caches binary signatures
 				// and SIGKILLs binaries with mismatched
 				// signatures. Overwriting a binary with
@@ -171,7 +171,7 @@ func untar(r io.Reader, dir string) (err error) {
 				_ = os.Chtimes(abs, modTime, modTime)
 			}
 		case tar.TypeDir:
-			if err := os.MkdirAll(abs, 0755); err != nil {
+			if err := os.MkdirAll(abs, 0o755); err != nil {
 				return err
 			}
 			madeDir[abs] = true

--- a/common/extract.go
+++ b/common/extract.go
@@ -101,17 +101,17 @@ func untar(r io.Reader, dir string) (err error) {
 
 	zr, err := gzip.NewReader(r)
 	if err != nil {
-		return fmt.Errorf("requires gzip-compressed body: %v", err)
+		return fmt.Errorf("requires gzip-compressed body: %w", err)
 	}
 
 	tr := tar.NewReader(zr)
 	for {
 		f, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("tar error: %v", err)
+			return fmt.Errorf("tar error: %w", err)
 		}
 		if !validRelPath(f.Name) {
 			return fmt.Errorf("tar contained invalid name error %q", f.Name)
@@ -154,7 +154,7 @@ func untar(r io.Reader, dir string) (err error) {
 				err = closeErr
 			}
 			if err != nil {
-				return fmt.Errorf("error writing to %s: %v", abs, err)
+				return fmt.Errorf("error writing to %s: %w", abs, err)
 			}
 			if n != f.Size {
 				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)

--- a/version.go
+++ b/version.go
@@ -46,7 +46,11 @@ func (v *GoVersion) String() string {
 		return fmt.Sprintf("%v.%v%v", seg[0], seg[1], v.version.Prerelease())
 	}
 
-	if len(seg) > 2 && seg[2] == 0 {
+	// Before 1.21 the initial minor releases didn't include a patch number. So
+	// the first 1.20 version was named with '1.20' instead of '1.20.0'. Starting
+	// in 1.21 the initial release includes the patch and was '1.21.0'. This formats
+	// version specifiers like 1.20.0 as 1.20.
+	if len(seg) > 2 && seg[2] == 0 && seg[0] <= 1 && seg[1] < 21 {
 		return fmt.Sprintf("%v.%v", seg[0], seg[1])
 	}
 	return v.version.String()


### PR DESCRIPTION
This makes the assumption that starting in 1.21 all future release will always include a patch number in their naming.

For example, previous versions were named like '1.20' and then '1.20.1' (there was no '1.20.0'). Now with 1.21 the first release was versioned as '1.20.0'.