### PR TITLE
Add wait between retries when there are download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated releases to use Go 1.18. [#54](https://github.com/andrewkroh/gvm/pull/54)
 - Report Go module version from `gvm --version` if installed via `go install`. [#57](https://github.com/andrewkroh/gvm/pull/57)
+- Add wait between retries when there are download errors. [#65](https://github.com/andrewkroh/gvm/pull/65)
 
 ### Fixed
 

--- a/binrepo.go
+++ b/binrepo.go
@@ -28,7 +28,7 @@ func (m *Manager) installBinary(version *GoVersion) (string, error) {
 	}
 
 	goURL := fmt.Sprintf("%s/go%v.%v-%v.%v", m.GoStorageHome, version, m.GOOS, m.GOARCH, extension)
-	path, err := common.DownloadFile(goURL, tmp, m.HTTPTimeout)
+	path, err := common.DownloadFile(goURL, tmp, m.HTTPTimeout, common.DefaultRetryParams)
 	if err != nil {
 		return "", fmt.Errorf("failed downloading from %v: %w", goURL, err)
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -23,9 +23,9 @@ type retryParams struct {
 	retryDelay time.Duration
 }
 
-var DefaultRetryParams retryParams = retryParams{
+var DefaultRetryParams = retryParams{
 	maxRetries: 5,
-	retryDelay: time.Duration(10 * time.Second),
+	retryDelay: 10 * time.Second,
 }
 
 func DownloadFile(url, destinationDir string, httpTimeout time.Duration, r retryParams) (string, error) {

--- a/common/common.go
+++ b/common/common.go
@@ -18,15 +18,27 @@ var log = logrus.WithField("package", "common")
 // ErrNotFound is returned when the download fails due to HTTP 404 Not Found.
 var ErrNotFound = errors.New("not found")
 
-func DownloadFile(url, destinationDir string, httpTimeout time.Duration) (string, error) {
+type retryParams struct {
+	maxRetries int
+	retryDelay time.Duration
+}
+
+var DefaultRetryParams retryParams = retryParams{
+	maxRetries: 5,
+	retryDelay: time.Duration(10 * time.Second),
+}
+
+func DownloadFile(url, destinationDir string, httpTimeout time.Duration, r retryParams) (string, error) {
 	log.WithField("url", url).Debug("Downloading file")
 	var name string
 	var err error
 	var retry bool
-	for a := 1; a <= 3; a++ {
+
+	for a := 1; a <= r.maxRetries; a++ {
 		name, retry, err = downloadFile(url, destinationDir, httpTimeout)
 		if err != nil && retry {
-			log.WithError(err).Debugf("Download attempt %d failed", a)
+			log.WithError(err).Debugf("Download attempt %d/%d failed, retrying in %s", a, r.maxRetries, r.retryDelay)
+			time.Sleep(r.retryDelay)
 			continue
 		}
 		break


### PR DESCRIPTION
Currently `gvm` makes three attempts at retrying a failed download, but it doesn't wait in between.

This commit adds rudimentary wait time between download attempts. It also increases the number
of retries to 5.

In a future refactoring we could use `go-retryablehttp`[^1] (we'd still need to guard for errors with `io.Copy`) but keeping the
improvement short for now, hoping to reduce download related CI failures.

[^1]: https://pkg.go.dev/github.com/hashicorp/go-retryablehttp#section-readme