### PR TITLE
enable gvm isntaller through a shell script

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,6 +33,25 @@ jobs:
           version: latest
           args: build --rm-dist --snapshot
 
+  gvm-install:
+    name: GoReleaser Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: run gvm-installer
+        run: ./gvm-install
+
+      - name: run gvm
+        run: |-
+          gvm --version
+          gvm help
+
   test-linux:
     name: Go Test (Linux)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-gvm
-===
+# gvm
 
 gvm is a Go version manager. gvm installs a Go version and prints the commands
 to configure your environment to use it. gvm can install Go binary versions from
@@ -21,8 +20,7 @@ powershell:
 gvm flags can be set via environment variables by setting `GVM_<flag>`. For
 example `--http-timeout` can be set via `GVM_HTTP_TIMEOUT=10m`.
 
-Installation
-------------
+## Manual installation
 
 You can download a binary release of `gvm` for your specific platform from the
 [releases](https://github.com/andrewkroh/gvm/releases) page. Then just put the
@@ -76,3 +74,17 @@ Use `gvm` with fish shell by executing `gvm 1.21.0 | source` in lieu of using `e
 For existing Go users:
 
 `go install github.com/andrewkroh/gvm/cmd/gvm@v0.5.2`
+
+## Single-line installation
+
+```shell
+curl -sSL https://raw.githubusercontent.com/andrewkroh/gvm/v0.5.2/gvm-installer | sh -s
+```
+
+If you use `wget` instead:
+
+```shell
+wget -qO- https://raw.githubusercontent.com/andrewkroh/gvm/v0.5.2/gvm-installer | sh -s
+```
+
+That will download the `gvm`, put it inside `$GOPATH/bin/`, give it execution rights with `chmod`, and setting the `GOPATH` environment variable and adding `$GOPATH/bin` to the PATH.

--- a/gvm-install
+++ b/gvm-install
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+GOPATH=${GOPATH:-$HOME/go}
+GVM_CMD="${GOPATH}/bin/gvm"
+export PATH="$GOPATH/bin:$PATH"
+
+## NOTE: Bump this version when a new release.
+VERSION=0.5.2
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" = "aarch64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+elif [ "${ARCH}" = "x86_64" ] ; then
+    GVM_ARCH_SUFFIX=amd64
+elif [ "${ARCH}" = "i686" ] ; then
+    GVM_ARCH_SUFFIX=386
+elif [ "${ARCH}" = "arm64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+else
+    GVM_ARCH_SUFFIX=arm
+fi
+
+mkdir -p "$GOPATH/bin"
+curl -sSLo "${GVM_CMD}" "https://github.com/andrewkroh/gvm/releases/download/v${VERSION}/gvm-${OS}-${GVM_ARCH_SUFFIX}"
+chmod +x "${GVM_CMD}"
+
+echo 'gvm has been installed correctly, you can now run: eval "$(gvm 1.21.0)" or similar'


### PR DESCRIPTION
Help with using `gvm` with a shell script installer,. This will help with removing all the logic to install `gvm` in the CI.

Caused by https://github.com/elastic/apm-agent-go/pull/1537/files#r1383052541