### PR TITLE
[Automation] Bump Go version to 1.23.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ examples for common shells.
 
 bash:
 
-`eval "$(gvm 1.23.5)"`
+`eval "$(gvm 1.23.6)"`
 
 cmd.exe (for batch scripts `%i` should be substituted with `%%i`):
 
-`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.23.5') DO %i`
+`FOR /f "tokens=*" %i IN ('"gvm.exe" 1.23.6') DO %i`
 
 powershell:
 
-`gvm --format=powershell 1.23.5 | Invoke-Expression`
+`gvm --format=powershell 1.23.6 | Invoke-Expression`
 
 gvm flags can be set via environment variables by setting `GVM_<flag>`. For
 example `--http-timeout` can be set via `GVM_HTTP_TIMEOUT=10m`.
@@ -36,7 +36,7 @@ Linux (amd64):
 # Linux Example (assumes ~/bin is in PATH).
 curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-linux-amd64
 chmod +x ~/bin/gvm
-eval "$(gvm 1.23.5)"
+eval "$(gvm 1.23.6)"
 go version
 ```
 
@@ -46,7 +46,7 @@ Linux (arm64):
 # Linux Example (assumes ~/bin is in PATH).
 curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-linux-arm64
 chmod +x ~/bin/gvm
-eval "$(gvm 1.23.5)"
+eval "$(gvm 1.23.6)"
 go version
 ```
 
@@ -56,7 +56,7 @@ macOS (universal):
 # macOS Example
 curl -sL -o /usr/local/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-darwin-all
 chmod +x /usr/local/bin/gvm
-eval "$(gvm 1.23.5)"
+eval "$(gvm 1.23.6)"
 go version
 ```
 
@@ -65,13 +65,13 @@ Windows (PowerShell):
 ```
 [Net.ServicePointManager]::SecurityProtocol = "tls12"
 Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-windows-amd64.exe -Outfile C:\Windows\System32\gvm.exe
-gvm --format=powershell 1.23.5 | Invoke-Expression
+gvm --format=powershell 1.23.6 | Invoke-Expression
 go version
 ```
 
 Fish Shell:
 
-Use `gvm` with fish shell by executing `gvm 1.23.5 | source` in lieu of using `eval`.
+Use `gvm` with fish shell by executing `gvm 1.23.6 | source` in lieu of using `eval`.
 
 For existing Go users:
 


### PR DESCRIPTION



<Actions>
    <action id="2f412339a648730f867ae1869a84633f1ad58300d98c03fd2989e66cca8f1443">
        <h3>Update Go version for andrewkroh/gvm</h3>
        <details id="c27cdcb9e7d276ca2fa04d67ef8dfe6f15632988c6c0e972d38da625e0b354eb">
            <summary>Update Go version in GVM readme.</summary>
            <p>1 file(s) updated with &#34; 1.23.6&#34;:&#xA;&#x9;* README.md&#xA;</p>
            <details>
                <summary>1.23.6</summary>
                <pre>no GitHub Release found for go1.23.6 on &#34;https://github.com/golang/go&#34;</pre>
            </details>
        </details>
        <a href="https://github.com/andrewkroh/updatecli-configs/actions/runs/13159074565">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

