### PR TITLE
fix linter warning for unused-parameter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,22 +7,18 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unused
-    - varcheck
     - errorlint
     - gofumpt
     - goimports
     - godox
-    - ifshort
     - misspell
     - prealloc
     - unconvert

--- a/cmd/gvm/gvm.go
+++ b/cmd/gvm/gvm.go
@@ -90,7 +90,7 @@ func main() {
 	app.UsageTemplate(kingpin.SeparateOptionalFlagsUsageTemplate)
 
 	// Enable debug.
-	app.PreAction(func(ctx *kingpin.ParseContext) error {
+	app.PreAction(func(*kingpin.ParseContext) error {
 		logrus.SetLevel(logrus.DebugLevel)
 		if *debug {
 			logrus.SetOutput(os.Stderr)


### PR DESCRIPTION
Fix warning for unused-parameter and remove deprecated linters from the golangci-lint configuration.